### PR TITLE
SEPolicy : Workaround for compile errors

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -181,6 +181,9 @@ VENDOR_SECURITY_PATCH := 2019-05-01
 # SELinux
 include device/qcom/sepolicy-legacy-um/SEPolicy.mk
 
+# Sepolicy
+SELINUX_IGNORE_NEVERALLOWS := true
+
 BOARD_SEPOLICY_DIRS += $(VENDOR_PATH)/sepolicy/vendor
 
 # Shim

--- a/sepolicy/vendor/property.te
+++ b/sepolicy/vendor/property.te
@@ -1,3 +1,4 @@
+type exported3_default_prop, property_type;
 vendor_internal_prop(audio_gain_prop)
 vendor_internal_prop(semc_version_prop)
 vendor_internal_prop(tareset_notfirstboot_prop)


### PR DESCRIPTION
I added exported3 context to property.te to fix the error : 
`libsepol.context_from_record: type exported3_default_prop is not defined
libsepol.context_from_record: could not create context structure
Sepol context check failed for u:object_r:exported3_default_prop:s0`

And then added neverallow ignore to BoardConfig to fix the **neverallow** error : 
`allow at /home/maru/android/out/target/product/kagura/obj/ETC/plat_sepolicy.cil_intermediates/plat_sepolicy.cil:8912
      (allow dumpstate property_type (file (read getattr map open)))
    <root>
`